### PR TITLE
SPOKE-2897 - enforced single quotes in literals and double in interpolations

### DIFF
--- a/config/rubocop-2.4.yml
+++ b/config/rubocop-2.4.yml
@@ -1226,8 +1226,8 @@ Style/SpecialGlobalVars:
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
-  Enabled: false
-  EnforcedStyle: double_quotes
+  Enabled: true
+  EnforcedStyle: single_quotes
   SupportedStyles:
   - single_quotes
   - double_quotes
@@ -1236,7 +1236,7 @@ Style/StringLiteralsInInterpolation:
   Description: Checks if uses of quotes inside expressions in interpolated strings
     match the configured preference.
   Enabled: true
-  EnforcedStyle: single_quotes
+  EnforcedStyle: double_quotes
   SupportedStyles:
   - single_quotes
   - double_quotes

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1219,8 +1219,8 @@ Style/SpecialGlobalVars:
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
-  Enabled: false
-  EnforcedStyle: double_quotes
+  Enabled: true
+  EnforcedStyle: single_quotes
   SupportedStyles:
   - single_quotes
   - double_quotes
@@ -1229,7 +1229,7 @@ Style/StringLiteralsInInterpolation:
   Description: Checks if uses of quotes inside expressions in interpolated strings
     match the configured preference.
   Enabled: true
-  EnforcedStyle: single_quotes
+  EnforcedStyle: double_quotes
   SupportedStyles:
   - single_quotes
   - double_quotes


### PR DESCRIPTION
changed base rubocop and rubocop-24 config files to address preference of single quotes vs double quotes except in interpolations where doubled are prefered.