### PR TITLE
SPOKE-2897-bis-enforce-single-quotes-vs-double-quotes

### DIFF
--- a/config/rubocop-2.4.yml
+++ b/config/rubocop-2.4.yml
@@ -1236,7 +1236,7 @@ Style/StringLiteralsInInterpolation:
   Description: Checks if uses of quotes inside expressions in interpolated strings
     match the configured preference.
   Enabled: true
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
   SupportedStyles:
   - single_quotes
   - double_quotes

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1229,7 +1229,7 @@ Style/StringLiteralsInInterpolation:
   Description: Checks if uses of quotes inside expressions in interpolated strings
     match the configured preference.
   Enabled: true
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
   SupportedStyles:
   - single_quotes
   - double_quotes


### PR DESCRIPTION
fixes a cop that shouldn't have changed. Use single quotes inside expressions in interpolations